### PR TITLE
Wattdave/master

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ additional details on each available environment variable.
 | `ECS_ENABLE_CPU_UNBOUNDED_WINDOWS_WORKAROUND` | `true` | When `true`, ECS will allow CPU unbounded(CPU=`0`) tasks to run along with CPU bounded tasks in Windows. | Not applicable | `false` |
 | `ECS_TASK_METADATA_RPS_LIMIT` | `100,150` | Comma separated integer values for steady state and burst throttle limits for task metadata endpoint | `40,60` | `40,60` |
 | `ECS_SHARED_VOLUME_MATCH_FULL_CONFIG` | `true` | When `true`, ECS Agent will compare name, driver options, and labels to make sure volumes are identical. When `false`, Agent will short circuit shared volume comparison if the names match. This is the default Docker behavior. If a volume is shared across instances, this should be set to `false`. | `false` | `false`|
+| `ECS_DOCKER_PULL_INACTIVITY_TIMEOUT` | 1m | The time to wait after docker pulls complete waiting for extraction of a container. Useful for tuning large Windows containers. | 1m | 1m |
 
 ### Persistence
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -77,6 +77,10 @@ const (
 	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
 	minimumTaskCleanupWaitDuration = 1 * time.Minute
 
+	// minimumDockerPullInactivityTimeout specifies the minimum duration to wait before cleaning up
+	// a task's container. This is used to enforce sane values for the config.TaskCleanupWaitDuration field.
+	minimumDockerPullInactivityTimeout = 1 * time.Minute
+
 	// minimumDockerStopTimeout specifies the minimum value for docker StopContainer API
 	minimumDockerStopTimeout = 1 * time.Second
 
@@ -255,6 +259,11 @@ func (cfg *Config) validateAndOverrideBounds() error {
 		cfg.TaskCleanupWaitDuration = DefaultTaskCleanupWaitDuration
 	}
 
+	if cfg.DockerPullInactivityTimeout < minimumDockerPullInactivityTimeout {
+		seelog.Warnf("Invalid value for docker pull inactivity timeout duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", defaultDockerPullInactivityTimeout.String(), cfg.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout)
+		cfg.TaskCleanupWaitDuration = defaultDockerPullInactivityTimeout
+	}
+
 	if cfg.ImageCleanupInterval < minimumImageCleanupInterval {
 		seelog.Warnf("Invalid value for image cleanup duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", DefaultImageCleanupTimeInterval.String(), cfg.ImageCleanupInterval, minimumImageCleanupInterval)
 		cfg.ImageCleanupInterval = DefaultImageCleanupTimeInterval
@@ -402,6 +411,7 @@ func environmentConfig() (Config, error) {
 		TaskCPUMemLimit:                  parseTaskCPUMemLimitEnabled(),
 		DockerStopTimeout:                parseDockerStopTimeout(),
 		ContainerStartTimeout:            parseContainerStartTimeout(),
+		DockerPullInactivityTimeout:	  parseDockerPullInactivityTimeout(),
 		CredentialsAuditLogFile:          os.Getenv("ECS_AUDIT_LOGFILE"),
 		CredentialsAuditLogDisabled:      utils.ParseBool(os.Getenv("ECS_AUDIT_LOGFILE_DISABLED"), false),
 		TaskIAMRoleEnabledForNetworkHost: utils.ParseBool(os.Getenv("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST"), false),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -261,7 +261,7 @@ func (cfg *Config) validateAndOverrideBounds() error {
 
 	if cfg.DockerPullInactivityTimeout < minimumDockerPullInactivityTimeout {
 		seelog.Warnf("Invalid value for docker pull inactivity timeout duration, will be overridden with the default value: %s. Parsed value: %v, minimum value: %v.", defaultDockerPullInactivityTimeout.String(), cfg.DockerPullInactivityTimeout, minimumDockerPullInactivityTimeout)
-		cfg.TaskCleanupWaitDuration = defaultDockerPullInactivityTimeout
+		cfg.DockerPullInactivityTimeout = defaultDockerPullInactivityTimeout
 	}
 
 	if cfg.ImageCleanupInterval < minimumImageCleanupInterval {

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -36,6 +36,8 @@ const (
 	defaultContainerStartTimeout = 3 * time.Minute
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 45 * time.Second
+	// default docker inactivity time is extra time needed on container extraction
+	defaultDockerPullInactivityTimeout = 1 * minute,
 )
 
 // DefaultConfig returns the default configuration for Linux

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -37,7 +37,7 @@ const (
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 45 * time.Second
 	// default docker inactivity time is extra time needed on container extraction
-	defaultDockerPullInactivityTimeout = 1 * time.Minute,
+	defaultDockerPullInactivityTimeout = 1 * time.Minute
 )
 
 // DefaultConfig returns the default configuration for Linux

--- a/agent/config/config_unix.go
+++ b/agent/config/config_unix.go
@@ -37,7 +37,7 @@ const (
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 45 * time.Second
 	// default docker inactivity time is extra time needed on container extraction
-	defaultDockerPullInactivityTimeout = 1 * minute,
+	defaultDockerPullInactivityTimeout = 1 * time.Minute,
 )
 
 // DefaultConfig returns the default configuration for Linux

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -46,6 +46,8 @@ const (
 	defaultContainerStartTimeout = 8 * time.Minute
 	// minimumContainerStartTimeout specifies the minimum value for starting a container
 	minimumContainerStartTimeout = 2 * time.Minute
+	// default docker inactivity time is extra time needed on container extraction
+	defaultDockerPullInactivityTimeout = 1 * time.Minute
 )
 
 // DefaultConfig returns the default configuration for Windows
@@ -80,6 +82,7 @@ func DefaultConfig() Config {
 		TaskCleanupWaitDuration:     DefaultTaskCleanupWaitDuration,
 		DockerStopTimeout:           defaultDockerStopTimeout,
 		ContainerStartTimeout:       defaultContainerStartTimeout,
+		DockerPullInactivityTimeout: defaultDockerPullInactivityTimeout,
 		CredentialsAuditLogFile:     filepath.Join(ecsRoot, defaultCredentialsAuditLogFile),
 		CredentialsAuditLogDisabled: false,
 		ImageCleanupDisabled:        false,

--- a/agent/config/parse.go
+++ b/agent/config/parse.go
@@ -91,6 +91,20 @@ func parseContainerStartTimeout() time.Duration {
 	return containerStartTimeout
 }
 
+func parseDockerPullInactivityTimeout() time.Duration {
+	var dockerPullInactivityTimeout time.Duration
+	parsedDockerPullInactivityTimeout := parseEnvVariableDuration("ECS_DOCKER_PULL_INACTIVITY_TIMEOUT")
+	if parsedDockerPullInactivityTimeout >= minimumDockerPullInactivityTimeout {
+		dockerPullInactivityTimeout = parsedDockerPullInactivityTimeout
+		// do the parsedStartTimeout != 0 check for the same reason as in getDockerStopTimeout()
+	} else if parsedDockerPullInactivityTimeout != 0 {
+		dockerPullInactivityTimeout = minimumDockerPullInactivityTimeout
+		seelog.Warnf("Discarded invalid value for docker pull inactivity timeout, parsed as: %v", parsedDockerPullInactivityTimeout)
+	}
+	return dockerPullInactivityTimeout
+}
+
+
 func parseAvailableLoggingDrivers() []dockerclient.LoggingDriver {
 	availableLoggingDriversEnv := os.Getenv("ECS_AVAILABLE_LOGGING_DRIVERS")
 	loggingDriverDecoder := json.NewDecoder(strings.NewReader(availableLoggingDriversEnv))

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -96,6 +96,9 @@ type Config struct {
 	// ContainerStartTimeout specifies the amount of time to wait to start a container
 	ContainerStartTimeout time.Duration
 
+	// DockerPullInactivityTimeout is here to override the amount of time to wait when extracting a container
+	DockerPullInactivityTimeout time.Duration
+
 	// AvailableLoggingDrivers specifies the logging drivers available for use
 	// with Docker.  If not set, it defaults to ["json-file","none"].
 	AvailableLoggingDrivers []dockerclient.LoggingDriver

--- a/agent/dockerclient/dockerapi/docker_client.go
+++ b/agent/dockerclient/dockerapi/docker_client.go
@@ -90,10 +90,6 @@ const (
 	// around a docker bug which sometimes results in pulls not progressing.
 	dockerPullBeginTimeout = 5 * time.Minute
 
-	// dockerPullInactivityTimeout is the amount of time that we will
-	// wait when the pulling does not progress
-	dockerPullInactivityTimeout = 1 * time.Minute
-
 	// pullStatusSuppressDelay controls the time where pull status progress bar
 	// output will be suppressed in debug mode
 	pullStatusSuppressDelay = 2 * time.Second
@@ -343,7 +339,7 @@ func (dg *dockerGoClient) pullImage(image string, authData *apicontainer.Registr
 	opts := docker.PullImageOptions{
 		Repository:        repository,
 		OutputStream:      pullWriter,
-		InactivityTimeout: dockerPullInactivityTimeout,
+		InactivityTimeout: dg.config.DockerPullInactivityTimeout,
 	}
 	timeout := dg.time().After(dockerPullBeginTimeout)
 	// pullBegan is a channel indicating that we have seen at least one line of data on the 'OutputStream' above.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
